### PR TITLE
rysujFFT shows accurate values for more than two samplings …

### DIFF
--- a/aseegg.py
+++ b/aseegg.py
@@ -197,7 +197,12 @@ def rysujFFT(sygnal, czestProbkowania, show_plot=True):
 
     plt.figure()
     plt.plot(f, wynik)
-    plt.xlim([0, int(czestProbkowania/2)])
+
+    plt.plot()
+
+    idx = int(czestProbkowania/2) if czestProbkowania < 100 else 50
+
+    plt.xlim([0, idx])
     plt.xlabel("Częstotliwość [Hz]")
     plt.ylabel(r'U [$\mu V$]')
     if show_plot:

--- a/aseegg.py
+++ b/aseegg.py
@@ -173,7 +173,7 @@ def FFT(sygnal):
     return wynik
 
 
-def rysujFFT(sygnal, show_plot=True):
+def rysujFFT(sygnal, czestProbkowania, show_plot=True):
     """Rysuj FFT (plot FFT).
     Parameters
     ----------
@@ -181,6 +181,11 @@ def rysujFFT(sygnal, show_plot=True):
         Polish: wektor z wartosciami sygnalu w jednostce czasu.
         English: signal -- vector of values acquired in given timepoints).
         May be array (or list) of: ints, floats, doubles.
+    czestProbkowania : int
+        Polish: czestotliwosc probkowania, ile razy na sekunde sygnal byl
+        pobierany (w herzach).
+        English: sampling frequency, how many samples are there acquires per
+        second (in herz).
     show_plot : bool, optional
         Polish: pokaz wygenerowany wykres lub tego nie rob. Ta druga opcja jest
         przydatna gdy chcemy nalozyc na siebie kilka funkcji.
@@ -188,13 +193,11 @@ def rysujFFT(sygnal, show_plot=True):
         of functions on the same canvas.
     """
     wynik = 2*abs(np.fft.fft(sygnal))/len(sygnal)
-    if len(sygnal) % 256 == 0:
-        f = np.linspace(0, 256, len(sygnal))
-    else:
-        f = np.linspace(0, 200, len(sygnal))
+    f = np.linspace(0, czestProbkowania, len(sygnal))
+
     plt.figure()
     plt.plot(f, wynik)
-    plt.xlim([0, 50])
+    plt.xlim([0, int(czestProbkowania/2)])
     plt.xlabel("Częstotliwość [Hz]")
     plt.ylabel(r'U [$\mu V$]')
     if show_plot:

--- a/aseegg.py
+++ b/aseegg.py
@@ -5,9 +5,9 @@
 Simple module for signal filtering and fast Fourier transform.
 """
 
-import scipy.signal as sig
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+import scipy.signal as sig
 
 
 def gornoprzepustowy(sygnal, czestProbkowania, czestOdciecia):
@@ -39,7 +39,7 @@ def gornoprzepustowy(sygnal, czestProbkowania, czestOdciecia):
         English: vector containing filtered signal.
     """
     rzad = 4
-    czestOdciecia = czestOdciecia/(czestProbkowania*0.5)
+    czestOdciecia = czestOdciecia / (czestProbkowania * 0.5)
     [b, a] = sig.butter(rzad, czestOdciecia, 'high')
     wynik = sig.filtfilt(b, a, sygnal)
     return wynik
@@ -74,7 +74,7 @@ def dolnoprzepustowy(sygnal, czestProbkowania, czestOdciecia):
         English: vector containing filtered signal.
     """
     rzad = 4
-    czestOdciecia = czestOdciecia/(czestProbkowania*0.5)
+    czestOdciecia = czestOdciecia / (czestProbkowania * 0.5)
     [b, a] = sig.butter(rzad, czestOdciecia, 'low')
     wynik = sig.filtfilt(b, a, sygnal)
     return wynik
@@ -111,8 +111,8 @@ def pasmowoprzepustowy(sygnal, czestProbkowania,
         English: vector containing filtered signal.
     """
     rzad = 4
-    czestOdciecia1 = czestOdciecia1/(czestProbkowania*0.5)
-    czestOdciecia2 = czestOdciecia2/(czestProbkowania*0.5)
+    czestOdciecia1 = czestOdciecia1 / (czestProbkowania * 0.5)
+    czestOdciecia2 = czestOdciecia2 / (czestProbkowania * 0.5)
     [b, a] = sig.butter(rzad, [czestOdciecia1, czestOdciecia2], 'bandpass')
     wynik = sig.filtfilt(b, a, sygnal)
     return wynik
@@ -148,8 +148,8 @@ def pasmowozaporowy(sygnal, czestProbkowania, czestOdciecia1, czestOdciecia2):
         English: vector containing filtered signal.
     """
     rzad = 4
-    czestOdciecia1 = czestOdciecia1/(czestProbkowania*0.5)
-    czestOdciecia2 = czestOdciecia2/(czestProbkowania*0.5)
+    czestOdciecia1 = czestOdciecia1 / (czestProbkowania * 0.5)
+    czestOdciecia2 = czestOdciecia2 / (czestProbkowania * 0.5)
     [b, a] = sig.butter(rzad, [czestOdciecia1, czestOdciecia2], 'bandstop')
     wynik = sig.filtfilt(b, a, sygnal)
     return wynik
@@ -169,7 +169,7 @@ def FFT(sygnal):
         Polish: przetransformowany sygnal.
         English: transformed signal.
     """
-    wynik = 2*abs(np.fft.fft(sygnal))/len(sygnal)
+    wynik = 2 * abs(np.fft.fft(sygnal)) / len(sygnal)
     return wynik
 
 
@@ -192,16 +192,14 @@ def rysujFFT(sygnal, czestProbkowania, show_plot=True):
         English: show graph. If it remains unplotted one can overlay a couple
         of functions on the same canvas.
     """
-    wynik = 2*abs(np.fft.fft(sygnal))/len(sygnal)
+    wynik = 2 * abs(np.fft.fft(sygnal)) / len(sygnal)
     f = np.linspace(0, czestProbkowania, len(sygnal))
 
     plt.figure()
     plt.plot(f, wynik)
-
     plt.plot()
 
-    idx = int(czestProbkowania/2) if czestProbkowania < 100 else 50
-
+    idx = int(czestProbkowania / 2) if czestProbkowania < 100 else 50
     plt.xlim([0, idx])
     plt.xlabel("Częstotliwość [Hz]")
     plt.ylabel(r'U [$\mu V$]')
@@ -223,8 +221,8 @@ def rysujPSD(sygnal, show_plot=True):
         English: show graph. If it remains unplotted one can overlay a couple
         of functions on the same canvas.
     """
-    wynik = 2*abs(np.fft.fft(sygnal))/len(sygnal)
-    wynik = np.conjugate(wynik)*wynik
+    wynik = 2 * abs(np.fft.fft(sygnal)) / len(sygnal)
+    wynik = np.conjugate(wynik) * wynik
     if len(sygnal) % 256 == 0:
         f = np.linspace(0, 256, len(sygnal))
     else:
@@ -269,12 +267,12 @@ def spektrogram(data, Fs, colormap=plt.cm.Accent, show_plot=True, ylim=50):
     data_padded = (np.concatenate((np.zeros(200), data, np.zeros(200))))
     Pxx, freqs, bins, im = plt.specgram(data_padded, NFFT=512, Fs=Fs,
                                         window=sig.hamming(512),
-                                        noverlap=2*Fs-1,
+                                        noverlap=2 * Fs - 1,
                                         # noverlap = Fs-1,
                                         cmap=plt.cm.jet)
 
     plt.ylim(0, ylim)
-    plt.xlim(0, len(data)/Fs)
+    plt.xlim(0, len(data) / Fs)
 
     if show_plot:
         plt.show()


### PR DESCRIPTION
but requires additional parameter and is not limited to static plot range. Previously plots were limited to two samplings and if an unexpected one occurred the plot was distorted. Now it requires sampling (czestProbkowania) parameter to calculate correct values. 

rysujFFT is plotted in the similar way to before (50 Hz limit), but when it gets sampling frequency lesser than 100 Hz it limits on lower value. This was done with regards to the Nyquist-Shannon theory claiming that the sampling frequency should be at least twice the maximum signal frequency.

Example of the FFT plot with sampling frequency=500 and signal low-pass filtered to contain only 10Hz:
![183076022_281529427004830_2471698223490268909_n](https://user-images.githubusercontent.com/36867695/117786729-1d106280-b246-11eb-9329-34e4e3c740d2.png)

After changes:
![after](https://user-images.githubusercontent.com/36867695/117787848-20581e00-b247-11eb-8a2e-69499d96e874.png)